### PR TITLE
feat: add pre-flight implementation checklist to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -14,7 +14,7 @@ body:
     id: proposal
     attributes:
       label: Proposal
-      value: _What’s the idea? Describe how it could work at a high level._
+      value: _What's the idea? Describe how it could work at a high level._
   - type: textarea
     id: alternatives
     attributes:
@@ -25,3 +25,27 @@ body:
     attributes:
       label: Impact
       value: _Who will benefit from this? How does it make things better?_
+  - type: textarea
+    id: pre_flight
+    attributes:
+      label: Pre-flight checklist
+      value: |
+        _Work through each of these items before implementation. Skip with
+        intent — if an item doesn't apply, note why in here._
+
+        - [ ] **Boundary & context** — belongs in an existing context, or a
+              new one created following the _How to add a new Phoenix context_
+              steps in `CLAUDE.md`
+        - [ ] **Database migration** — new tables/columns generated with
+              `mix ecto.gen.migration` using `binary_id` keys
+        - [ ] **Authentication & authorisation** — correct router scope
+              chosen (`:require_authenticated_user`, `:require_kingdom`, or
+              public)
+        - [ ] **Feature flag** — rolls out gradually behind a
+              `KingdoneCore.FeatureFlags` flag enabled via `/dev/flags`; or
+              noted in the PR description why a flag is not needed
+        - [ ] **Background jobs** — deferred/retried work uses an Oban worker
+        - [ ] **Tests** — LiveView integration tests with `PhoenixTest`;
+              context unit tests; both flag states covered if feature-flagged
+        - [ ] **IEx helpers** — `.iex.exs` updated for any new schemas
+        - [ ] **CLAUDE.md** — new patterns or conventions documented


### PR DESCRIPTION
## Summary

- Adds a **Pre-flight checklist** textarea field to the feature issue template
- The field pre-populates with 8 implementation checkboxes covering: boundary/context, DB migration, auth, feature flag, background jobs, tests, IEx helpers, and CLAUDE.md docs
- Follows the same `textarea` + `value` pattern as the existing fields, so the checklist is visible even if the author skips it — it can be ticked off later during triage

## Context

This checklist was designed as part of integrating `fun_with_flags` into the kingdone project ([issue #100](https://github.com/0k-software/kingdone/issues/100)). It captures the recurring implementation concerns that every feature should evaluate before coding begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)