### PR TITLE
Add default make target for setup and skill installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ GIT_HOOKS_DST := .git/hooks
 
 HOOK_FILES := $(wildcard $(GIT_HOOKS_SRC)/*)
 
+.PHONY: all
+all: setup install-skills
+
 .PHONY: setup
 setup:
 	@mkdir -p $(GIT_HOOKS_DST)


### PR DESCRIPTION
## Summary
Added a default `all` target to the Makefile that orchestrates the initial setup and skill installation workflow.

## Key Changes
- Added `.PHONY: all` declaration to define `all` as a phony target
- Created `all` target that depends on `setup` and `install-skills` targets, establishing a clear initialization sequence

## Implementation Details
The new `all` target serves as the entry point for users running `make` without arguments, automatically executing both the setup phase (creating necessary git hooks directories) and the skill installation phase in the correct order. This improves the user experience by providing a single command to fully initialize the project.

https://claude.ai/code/session_014hDNBFgYvyVGcLmj3dJSrw