### PR TITLE
Add package-skills make target to create skills archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+skills.zip

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ install-skills: sync-skill-templates
 	done
 	@echo "Installed $(words $(SKILL_DIRS)) skill(s) to $(SKILLS_HOME)/"
 
+SKILLS_ZIP := skills.zip
+
+.PHONY: package-skills
+package-skills: sync-skill-templates
+	@rm -f $(SKILLS_ZIP)
+	@cd $(SKILLS_SRC) && zip -r ../../$(SKILLS_ZIP) $(notdir $(SKILL_DIRS))
+	@echo "Packaged $(words $(SKILL_DIRS)) skill(s) into $(SKILLS_ZIP)"
+
 .PHONY: uninstall-skills
 uninstall-skills:
 	@for dir in $(SKILL_DIRS); do \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_HOOKS_DST := .git/hooks
 HOOK_FILES := $(wildcard $(GIT_HOOKS_SRC)/*)
 
 .PHONY: all
-all: setup install-skills
+all: setup install-skills package-skills
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
## Summary
Added a new `package-skills` make target that bundles all installed skills into a `skills.zip` archive file for distribution or backup purposes.

## Key Changes
- Added `package-skills` make target that:
  - Removes any existing `skills.zip` file
  - Creates a new zip archive containing all skill directories
  - Outputs a summary message with the number of skills packaged
- Added `skills.zip` to `.gitignore` to prevent the generated archive from being committed

## Implementation Details
- The `package-skills` target depends on `sync-skill-templates` to ensure skills are up-to-date before packaging
- Uses `zip -r` to recursively archive skill directories from the `$(SKILLS_SRC)` location
- The archive is created in the project root directory for easy access

https://claude.ai/code/session_01W25F5hu7HUEcF6dQ7y4vB5