### PR TITLE
Refactor skills packaging to generate individual skill archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-skills.zip
+dist/

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,18 @@ install-skills: sync-skill-templates
 	done
 	@echo "Installed $(words $(SKILL_DIRS)) skill(s) to $(SKILLS_HOME)/"
 
-SKILLS_ZIP := skills.zip
+SKILLS_DIST := dist/skills
 
 .PHONY: package-skills
 package-skills: sync-skill-templates
-	@rm -f $(SKILLS_ZIP)
-	@cd $(SKILLS_SRC) && zip -r ../../$(SKILLS_ZIP) $(notdir $(SKILL_DIRS))
-	@echo "Packaged $(words $(SKILL_DIRS)) skill(s) into $(SKILLS_ZIP)"
+	@rm -rf $(SKILLS_DIST)
+	@mkdir -p $(SKILLS_DIST)
+	@for dir in $(SKILL_DIRS); do \
+		name=$$(basename "$$dir"); \
+		cd $(SKILLS_SRC) && zip -r ../../$(SKILLS_DIST)/$$name.zip $$name && cd ../..; \
+		echo "Packaged $$name -> $(SKILLS_DIST)/$$name.zip"; \
+	done
+	@echo "Packaged $(words $(SKILL_DIRS)) skill(s) into $(SKILLS_DIST)/"
 
 .PHONY: uninstall-skills
 uninstall-skills:


### PR DESCRIPTION
## Summary
Changed the skills packaging process to generate individual ZIP archives for each skill in a `dist/skills/` directory instead of creating a single monolithic `skills.zip` file.

## Key Changes
- **Output structure**: Replaced single `skills.zip` with individual skill archives in `dist/skills/` directory (e.g., `dist/skills/skill-name.zip`)
- **Packaging logic**: Updated `package-skills` target to iterate over each skill and create separate ZIP files rather than bundling all skills together
- **Build artifacts**: Updated `.gitignore` to ignore the entire `dist/` directory instead of just `skills.zip`

## Implementation Details
- The `SKILLS_DIST` variable now points to `dist/skills` as the output directory
- The packaging loop creates the distribution directory structure and generates individual archives for each skill
- Each skill's archive is created with its own ZIP file named after the skill
- Progress output now shows individual skill packaging confirmations

https://claude.ai/code/session_01DmxMo9Hp6RN6KWctQ2aq3P