### PR TITLE
Add scripts to sync org skills across 0k-software projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,45 @@ Claude Code skills live in `.claude/skills/`. To install them globally
 make install-skills
 ```
 
+### Making skills available in remote sessions (other 0k-software projects)
+
+Remote Claude Code sessions don't have access to `~/.claude/skills/`, so skills
+must be present in the project's own `.claude/skills/`. To share these org
+skills across projects without silently stale copies, add this `SessionStart`
+hook to the other project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash <(curl -fsSL https://raw.githubusercontent.com/0k-software/.github/main/bin/ensure-org-skills)"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**What it does:**
+
+- **Missing skills** are installed automatically into `.claude/skills/`. Commit
+  the new files so they persist across sessions.
+- **Outdated skills** (local copy differs from this repo) trigger a warning
+  with instructions — no silent overwrites.
+
+**To manually update outdated skills:**
+
+```
+bash <(curl -fsSL https://raw.githubusercontent.com/0k-software/.github/main/bin/update-org-skills)
+```
+
+Review the diff (`git diff .claude/skills/`) and commit when satisfied.
+
 ## Editing Guidelines
 
 - Maintain the numeric prefix naming convention for templates to preserve

--- a/bin/ensure-org-skills
+++ b/bin/ensure-org-skills
@@ -24,6 +24,7 @@ set -uo pipefail
 GITHUB_ORG="0k-software"
 GITHUB_REPO=".github"
 BRANCH="main"
+API_BASE="https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO"
 RAW_BASE="https://raw.githubusercontent.com/$GITHUB_ORG/$GITHUB_REPO/$BRANCH"
 SKILLS_DIR=".claude/skills"
 
@@ -32,47 +33,56 @@ if git remote -v 2>/dev/null | grep -qF "0k-software/.github"; then
   exit 0
 fi
 
-# Skill name -> space-separated list of files (relative to the skill directory)
-declare -A SKILL_FILES
-SKILL_FILES["0k-commit"]="SKILL.md"
-SKILL_FILES["0k-rebase"]="SKILL.md"
-SKILL_FILES["0k-plan"]="SKILL.md"
-SKILL_FILES["0k-fix-pr"]="SKILL.md"
-SKILL_FILES["0k-create-issue"]="SKILL.md templates/1-pitch.yml templates/2-feature.yml templates/3-task.yml templates/4-bug.yml templates/5-enhancement.yml templates/6-kickoff.yml"
-
-fetch() {
-  curl -fsSL "$1" 2>/dev/null
+# Discover all skill files via the GitHub git trees API (one recursive call).
+# Files always have an extension; directory tree entries don't — use that to filter.
+tree_json=$(curl -fsSL "$API_BASE/git/trees/$BRANCH?recursive=1" 2>/dev/null) || {
+  echo "warn: could not reach GitHub API, skipping org skills check" >&2
+  exit 0
 }
+
+skill_paths=$(printf '%s\n' "$tree_json" \
+  | grep -o '"path":"\.claude/skills/0k-[^"]*"' \
+  | sed 's/"path":"//;s/"$//' \
+  | grep '\.')
+
+if [ -z "$skill_paths" ]; then
+  echo "warn: no skills found in 0k-software/.github" >&2
+  exit 0
+fi
+
+# Collect unique skill names
+skill_names=$(printf '%s\n' "$skill_paths" \
+  | sed 's|\.claude/skills/\([^/]*\)/.*|\1|' \
+  | sort -u)
 
 install_skill() {
   local skill="$1"
-  # shellcheck disable=SC2086
-  for file in ${SKILL_FILES[$skill]}; do
-    local local_path="$SKILLS_DIR/$skill/$file"
-    local remote_url="$RAW_BASE/$SKILLS_DIR/$skill/$file"
-    mkdir -p "$(dirname "$local_path")"
-    if ! fetch "$remote_url" > "$local_path"; then
-      echo "  warn: failed to fetch $skill/$file" >&2
-      rm -f "$local_path"
+  local paths
+  paths=$(printf '%s\n' "$skill_paths" | grep "^\\.claude/skills/$skill/")
+  while IFS= read -r path; do
+    mkdir -p "$(dirname "$path")"
+    if ! curl -fsSL "$RAW_BASE/$path" > "$path" 2>/dev/null; then
+      echo "  warn: failed to fetch $path" >&2
+      rm -f "$path"
     fi
-  done
+  done <<< "$paths"
 }
 
 missing=()
 outdated=()
 
-for skill in "${!SKILL_FILES[@]}"; do
+while IFS= read -r skill; do
   local_md="$SKILLS_DIR/$skill/SKILL.md"
 
   if [ ! -f "$local_md" ]; then
     missing+=("$skill")
   else
-    remote_md=$(fetch "$RAW_BASE/$SKILLS_DIR/$skill/SKILL.md") || continue
+    remote_md=$(curl -fsSL "$RAW_BASE/$SKILLS_DIR/$skill/SKILL.md" 2>/dev/null) || continue
     if [ "$remote_md" != "$(cat "$local_md")" ]; then
       outdated+=("$skill")
     fi
   fi
-done
+done <<< "$skill_names"
 
 if [ ${#missing[@]} -gt 0 ]; then
   echo "Installing org skills:"

--- a/bin/ensure-org-skills
+++ b/bin/ensure-org-skills
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# ensure-org-skills: Install missing 0k-software org skills; warn about outdated ones.
+#
+# Run as a Claude Code SessionStart hook in any 0k-software project by adding this
+# to the project's .claude/settings.json:
+#
+#   {
+#     "hooks": {
+#       "SessionStart": [{
+#         "hooks": [{
+#           "type": "command",
+#           "command": "bash <(curl -fsSL https://raw.githubusercontent.com/0k-software/.github/main/bin/ensure-org-skills)"
+#         }]
+#       }]
+#     }
+#   }
+#
+# Missing skills are installed automatically. Outdated skills are flagged with
+# instructions so developers can update manually (no silent overwrites).
+#
+set -uo pipefail
+
+GITHUB_ORG="0k-software"
+GITHUB_REPO=".github"
+BRANCH="main"
+RAW_BASE="https://raw.githubusercontent.com/$GITHUB_ORG/$GITHUB_REPO/$BRANCH"
+SKILLS_DIR=".claude/skills"
+
+# Skip when running inside the source repo itself
+if git remote -v 2>/dev/null | grep -qF "0k-software/.github"; then
+  exit 0
+fi
+
+# Skill name -> space-separated list of files (relative to the skill directory)
+declare -A SKILL_FILES
+SKILL_FILES["0k-commit"]="SKILL.md"
+SKILL_FILES["0k-rebase"]="SKILL.md"
+SKILL_FILES["0k-plan"]="SKILL.md"
+SKILL_FILES["0k-fix-pr"]="SKILL.md"
+SKILL_FILES["0k-create-issue"]="SKILL.md templates/1-pitch.yml templates/2-feature.yml templates/3-task.yml templates/4-bug.yml templates/5-enhancement.yml templates/6-kickoff.yml"
+
+fetch() {
+  curl -fsSL "$1" 2>/dev/null
+}
+
+install_skill() {
+  local skill="$1"
+  # shellcheck disable=SC2086
+  for file in ${SKILL_FILES[$skill]}; do
+    local local_path="$SKILLS_DIR/$skill/$file"
+    local remote_url="$RAW_BASE/$SKILLS_DIR/$skill/$file"
+    mkdir -p "$(dirname "$local_path")"
+    if ! fetch "$remote_url" > "$local_path"; then
+      echo "  warn: failed to fetch $skill/$file" >&2
+      rm -f "$local_path"
+    fi
+  done
+}
+
+missing=()
+outdated=()
+
+for skill in "${!SKILL_FILES[@]}"; do
+  local_md="$SKILLS_DIR/$skill/SKILL.md"
+
+  if [ ! -f "$local_md" ]; then
+    missing+=("$skill")
+  else
+    remote_md=$(fetch "$RAW_BASE/$SKILLS_DIR/$skill/SKILL.md") || continue
+    if [ "$remote_md" != "$(cat "$local_md")" ]; then
+      outdated+=("$skill")
+    fi
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "Installing org skills:"
+  for skill in "${missing[@]}"; do
+    install_skill "$skill"
+    echo "  + $skill"
+  done
+  echo ""
+  echo "Commit the new files in $SKILLS_DIR/ to persist them for future sessions."
+fi
+
+if [ ${#outdated[@]} -gt 0 ]; then
+  echo ""
+  echo "These org skills are outdated: ${outdated[*]}"
+  echo "To update, copy the latest versions from 0k-software/.github/.claude/skills/"
+  echo "or run: bash <(curl -fsSL $RAW_BASE/bin/update-org-skills)"
+fi

--- a/bin/update-org-skills
+++ b/bin/update-org-skills
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# update-org-skills: Overwrite local org skills with the latest from 0k-software/.github.
+#
+# Run this manually when ensure-org-skills reports outdated skills:
+#
+#   bash <(curl -fsSL https://raw.githubusercontent.com/0k-software/.github/main/bin/update-org-skills)
+#
+# Unlike ensure-org-skills (which only installs missing skills and warns about
+# outdated ones), this script always overwrites with the remote version.
+#
+set -uo pipefail
+
+GITHUB_ORG="0k-software"
+GITHUB_REPO=".github"
+BRANCH="main"
+RAW_BASE="https://raw.githubusercontent.com/$GITHUB_ORG/$GITHUB_REPO/$BRANCH"
+SKILLS_DIR=".claude/skills"
+
+# Skip when running inside the source repo itself
+if git remote -v 2>/dev/null | grep -qF "0k-software/.github"; then
+  echo "Already in the source repo — nothing to do." >&2
+  exit 0
+fi
+
+declare -A SKILL_FILES
+SKILL_FILES["0k-commit"]="SKILL.md"
+SKILL_FILES["0k-rebase"]="SKILL.md"
+SKILL_FILES["0k-plan"]="SKILL.md"
+SKILL_FILES["0k-fix-pr"]="SKILL.md"
+SKILL_FILES["0k-create-issue"]="SKILL.md templates/1-pitch.yml templates/2-feature.yml templates/3-task.yml templates/4-bug.yml templates/5-enhancement.yml templates/6-kickoff.yml"
+
+fetch() {
+  curl -fsSL "$1" 2>/dev/null
+}
+
+updated=0
+failed=0
+
+for skill in "${!SKILL_FILES[@]}"; do
+  echo "Updating $skill..."
+  # shellcheck disable=SC2086
+  for file in ${SKILL_FILES[$skill]}; do
+    local_path="$SKILLS_DIR/$skill/$file"
+    remote_url="$RAW_BASE/$SKILLS_DIR/$skill/$file"
+    mkdir -p "$(dirname "$local_path")"
+    if fetch "$remote_url" > "$local_path"; then
+      updated=$((updated + 1))
+    else
+      echo "  warn: failed to fetch $skill/$file" >&2
+      rm -f "$local_path"
+      failed=$((failed + 1))
+    fi
+  done
+done
+
+echo ""
+echo "Updated $updated file(s)${failed:+, $failed failed}."
+echo "Review the changes and commit when satisfied."

--- a/bin/update-org-skills
+++ b/bin/update-org-skills
@@ -14,8 +14,8 @@ set -uo pipefail
 GITHUB_ORG="0k-software"
 GITHUB_REPO=".github"
 BRANCH="main"
+API_BASE="https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO"
 RAW_BASE="https://raw.githubusercontent.com/$GITHUB_ORG/$GITHUB_REPO/$BRANCH"
-SKILLS_DIR=".claude/skills"
 
 # Skip when running inside the source repo itself
 if git remote -v 2>/dev/null | grep -qF "0k-software/.github"; then
@@ -23,36 +23,36 @@ if git remote -v 2>/dev/null | grep -qF "0k-software/.github"; then
   exit 0
 fi
 
-declare -A SKILL_FILES
-SKILL_FILES["0k-commit"]="SKILL.md"
-SKILL_FILES["0k-rebase"]="SKILL.md"
-SKILL_FILES["0k-plan"]="SKILL.md"
-SKILL_FILES["0k-fix-pr"]="SKILL.md"
-SKILL_FILES["0k-create-issue"]="SKILL.md templates/1-pitch.yml templates/2-feature.yml templates/3-task.yml templates/4-bug.yml templates/5-enhancement.yml templates/6-kickoff.yml"
-
-fetch() {
-  curl -fsSL "$1" 2>/dev/null
+# Discover all skill files via the GitHub git trees API (one recursive call).
+# Files always have an extension; directory tree entries don't — use that to filter.
+tree_json=$(curl -fsSL "$API_BASE/git/trees/$BRANCH?recursive=1" 2>/dev/null) || {
+  echo "error: could not reach GitHub API" >&2
+  exit 1
 }
+
+skill_paths=$(printf '%s\n' "$tree_json" \
+  | grep -o '"path":"\.claude/skills/0k-[^"]*"' \
+  | sed 's/"path":"//;s/"$//' \
+  | grep '\.')
+
+if [ -z "$skill_paths" ]; then
+  echo "error: no skills found in 0k-software/.github" >&2
+  exit 1
+fi
 
 updated=0
 failed=0
 
-for skill in "${!SKILL_FILES[@]}"; do
-  echo "Updating $skill..."
-  # shellcheck disable=SC2086
-  for file in ${SKILL_FILES[$skill]}; do
-    local_path="$SKILLS_DIR/$skill/$file"
-    remote_url="$RAW_BASE/$SKILLS_DIR/$skill/$file"
-    mkdir -p "$(dirname "$local_path")"
-    if fetch "$remote_url" > "$local_path"; then
-      updated=$((updated + 1))
-    else
-      echo "  warn: failed to fetch $skill/$file" >&2
-      rm -f "$local_path"
-      failed=$((failed + 1))
-    fi
-  done
-done
+while IFS= read -r path; do
+  mkdir -p "$(dirname "$path")"
+  if curl -fsSL "$RAW_BASE/$path" > "$path" 2>/dev/null; then
+    updated=$((updated + 1))
+  else
+    echo "warn: failed to fetch $path" >&2
+    rm -f "$path"
+    failed=$((failed + 1))
+  fi
+done <<< "$skill_paths"
 
 echo ""
 echo "Updated $updated file(s)${failed:+, $failed failed}."


### PR DESCRIPTION
## Summary

Add automation to keep Claude Code skills synchronized across 0k-software projects without silent overwrites. This enables remote Claude Code sessions to access shared org skills while maintaining control over updates.

## Changes

- **`bin/ensure-org-skills`**: New script that automatically installs missing org skills into `.claude/skills/` and warns about outdated ones. Designed to run as a `SessionStart` hook in project `.claude/settings.json`.

- **`bin/update-org-skills`**: New script for manually updating outdated skills. Overwrites local copies with the latest versions from the source repo.

- **`AGENTS.md`**: Added documentation explaining how to enable skill synchronization in other 0k-software projects, including:
  - Configuration instructions for `.claude/settings.json`
  - Explanation of automatic vs. manual update behavior
  - Usage examples for both scripts

## Implementation Details

- Both scripts fetch skill files from `0k-software/.github` via raw GitHub URLs
- `ensure-org-skills` compares local `SKILL.md` with remote to detect outdated skills
- Scripts skip execution when run inside the source repo itself
- Missing skills are installed automatically; outdated skills require manual review before committing
- Supports skills with multiple files (e.g., `0k-create-issue` includes templates)
- Comprehensive error handling with warnings for failed fetches

https://claude.ai/code/session_013Th496LiF2bAsWzNAvJRLh