### PR TITLE
feat(0k-refine-issue): remove confirmation gates for autonomous execution

### DIFF
--- a/.claude/skills/0k-commit/SKILL.md
+++ b/.claude/skills/0k-commit/SKILL.md
@@ -37,5 +37,7 @@ changes and use it to write the commit body.
      attempt to fix it yourself.
    - **Auto-fix mode** (`!`): diagnose the failure (e.g. pre-commit hook
      lint/format errors), fix the issue, re-stage with `git add .`, and retry
-     the commit. If the fix attempt also fails, report the error but still do
-     **not** abort — let the calling skill decide how to proceed.
+     the commit. If the fix attempt also fails, report the error, clearly state
+     that **no commit was created**, and return control to the caller as a
+     handled error. Do **not** fabricate or report a commit SHA, and do **not**
+     claim success for commit-dependent workflows.

--- a/.claude/skills/0k-commit/SKILL.md
+++ b/.claude/skills/0k-commit/SKILL.md
@@ -2,13 +2,25 @@
 name: 0k-commit
 description:
   Stage all changes (staged, unstaged, and untracked) and generate a
-  Conventional Commit message
+  Conventional Commit message — use `!` prefix to auto-fix errors instead of
+  aborting
 ---
 
 Stage everything and generate a git commit message, then commit.
 
-Here's the context provided by the user: "$ARGUMENTS". If provided, treat it as
-the reason/motivation behind the changes and use it to write the commit body.
+## Argument parsing
+
+`$ARGUMENTS` may start with `!` (e.g. `! fixed the bug`). Strip the leading `!`
+and whitespace to obtain the **context text**. If `!` is present, the skill
+runs in **auto-fix mode** (see Step 6).
+
+If `$ARGUMENTS` does not start with `!`, the entire string is the context text
+and the skill runs in **interactive mode**.
+
+If the context text is non-empty, treat it as the reason/motivation behind the
+changes and use it to write the commit body.
+
+## Steps
 
 1. Run `git add .` to stage all changes (staged, unstaged, and untracked).
 2. Run `git diff --no-ext-diff --staged` to get the diff to be committed.
@@ -20,5 +32,10 @@ the reason/motivation behind the changes and use it to write the commit body.
 4. Display the generated commit message with a horizontal rule (`\n\n---\n\n`)
    before and after it so it stands out clearly.
 5. Run `git commit -m "..."` using a heredoc to preserve formatting.
-6. If any error occurs during the commit process, display an error message and
-   abort, **do not attempt to fix it yourself**.
+6. **On error:**
+   - **Interactive mode** (no `!`): display the error and abort. Do **not**
+     attempt to fix it yourself.
+   - **Auto-fix mode** (`!`): diagnose the failure (e.g. pre-commit hook
+     lint/format errors), fix the issue, re-stage with `git add .`, and retry
+     the commit. If the fix attempt also fails, report the error but still do
+     **not** abort — let the calling skill decide how to proceed.

--- a/.claude/skills/0k-fix-pr/SKILL.md
+++ b/.claude/skills/0k-fix-pr/SKILL.md
@@ -143,8 +143,8 @@ change requests). This prevents future runs from re-addressing the same
 feedback.
 
 ```
-gh api "repos/<owner>/<repo>/pulls/comments/<comment-id>/reactions" \
-  -f content="eyes"
+gh api "repos/<owner>/<repo>/pulls/comments/<databaseId>/reactions" \
+  -X POST -f content="eyes"
 ```
 
 ## Step 6 — Report

--- a/.claude/skills/0k-fix-pr/SKILL.md
+++ b/.claude/skills/0k-fix-pr/SKILL.md
@@ -40,7 +40,16 @@ branch (prefer the GitHub MCP tools; fall back to
    ```
 3. **Discard** every thread where `isResolved` is `true`. Keep only unresolved
    threads.
-4. For each remaining thread, record all comments in order. The **last comment
+4. For each remaining thread, check whether its **first comment** has an `eyes`
+   (👀) reaction from the authenticated user:
+   ```
+   gh api "repos/<owner>/<repo>/pulls/comments/<comment-id>/reactions" \
+     --jq '[.[] | select(.content == "eyes")]'
+   ```
+   Threads already marked with `eyes` have been addressed in a previous run.
+   Keep them as **context** (they may inform code changes) but do **not**
+   re-classify, re-implement, or reply to them again.
+5. For each remaining thread, record all comments in order. The **last comment
    in the thread** takes precedence — if a later reply changes or overrides the
    original request, follow the latest instruction.
 
@@ -118,7 +127,19 @@ Include the commit URL in the reply. Derive it from the SHA:
 gh api "repos/<owner>/<repo>/commits/<sha>" --jq .html_url
 ```
 
-## Step 5 — Report
+## Step 5 — Mark threads as addressed
+
+After posting all replies and pushing, react with `eyes` (👀) to the **first
+comment** of every thread that was addressed in this run (both questions and
+change requests). This prevents future runs from re-addressing the same
+feedback.
+
+```
+gh api "repos/<owner>/<repo>/pulls/comments/<comment-id>/reactions" \
+  -f content="eyes"
+```
+
+## Step 6 — Report
 
 After all comments are handled, display a summary:
 

--- a/.claude/skills/0k-fix-pr/SKILL.md
+++ b/.claude/skills/0k-fix-pr/SKILL.md
@@ -40,15 +40,23 @@ branch (prefer the GitHub MCP tools; fall back to
    ```
 3. **Discard** every thread where `isResolved` is `true`. Keep only unresolved
    threads.
-4. For each remaining thread, check whether its **first comment** has an `eyes`
-   (👀) reaction from the authenticated user:
+4. For each remaining thread, check whether its **first comment** (using its
+   `databaseId` — not the opaque GraphQL `id`) has an `eyes` (👀) reaction from
+   the authenticated user:
+
    ```
-   gh api "repos/<owner>/<repo>/pulls/comments/<comment-id>/reactions" \
-     --jq '[.[] | select(.content == "eyes")]'
+   viewer="$(gh api user --jq .login)"
+   gh api --paginate "repos/{owner}/{repo}/pulls/comments/{databaseId}/reactions" \
+     --jq --arg viewer "$viewer" '[.[] | select(.content == "eyes" and .user.login == $viewer)]'
    ```
+
    Threads already marked with `eyes` have been addressed in a previous run.
    Keep them as **context** (they may inform code changes) but do **not**
    re-classify, re-implement, or reply to them again.
+
+   **Important:** All REST API calls under `pulls/comments/` expect the numeric
+   `databaseId` from the GraphQL response, not the opaque `id`.
+
 5. For each remaining thread, record all comments in order. The **last comment
    in the thread** takes precedence — if a later reply changes or overrides the
    original request, follow the latest instruction.

--- a/.claude/skills/0k-fix-pr/SKILL.md
+++ b/.claude/skills/0k-fix-pr/SKILL.md
@@ -98,7 +98,7 @@ For each group of related change requests, in order:
 
 1. Read the files involved to understand the full context.
 2. Implement the requested change(s) — and **only** those changes.
-3. Run `/0k-commit` with the change request context as the argument.
+3. Run `/0k-commit !` with the change request context as the argument.
 4. Record the resulting commit SHA alongside the group (you will need it in
    Step 4c). Then **immediately continue to the next group** — do not push yet.
 

--- a/.claude/skills/0k-plan/SKILL.md
+++ b/.claude/skills/0k-plan/SKILL.md
@@ -58,7 +58,7 @@ each step describing what to implement and how.
 ### `next`
 
 Read PLAN.md and implement the next unchecked step. Once done, mark the step as
-done (`- [x]`) in the PLAN.md TOC and run `/0k-commit` with the step
+done (`- [x]`) in the PLAN.md TOC and run `/0k-commit !` with the step
 title/description as context.
 
 If the implementation required any deviation from the original step description

--- a/.claude/skills/0k-plan/SKILL.md
+++ b/.claude/skills/0k-plan/SKILL.md
@@ -50,6 +50,11 @@ Based on `$ARGUMENTS`, run one of the following:
 
 ### `init {gh-url}`
 
+`{gh-url}` is an issue number or URL. If empty, try to infer the issue number
+from the current branch name — if the branch name starts with digits (e.g.
+`42-some-feature`), use that number. If no number can be inferred, ask the user
+which issue to plan.
+
 Plan the GH issue at `{gh-url}`. Fetch the issue details, then create PLAN.md
 following the format above. Include the link, a summary of the issue, the
 overall approach, a TOC checklist with anchor links, and a detailed section for

--- a/.claude/skills/0k-plan/SKILL.md
+++ b/.claude/skills/0k-plan/SKILL.md
@@ -55,6 +55,16 @@ following the format above. Include the link, a summary of the issue, the
 overall approach, a TOC checklist with anchor links, and a detailed section for
 each step describing what to implement and how.
 
+After creating PLAN.md:
+
+1. Run `/0k-commit ! plan: {issue title}` to commit it.
+2. Push the branch and open a **draft** PR linking to the issue:
+   ```
+   git push -u origin HEAD
+   gh pr create --draft --title "[{issue-number}] {issue title}" \
+     --body "Closes {gh-url}" --head "$(git branch --show-current)"
+   ```
+
 ### `next`
 
 Read PLAN.md and implement the next unchecked step. Once done, mark the step as

--- a/.claude/skills/0k-refine-issue/SKILL.md
+++ b/.claude/skills/0k-refine-issue/SKILL.md
@@ -56,17 +56,15 @@ Group the feedback into:
 | **Acknowledgement**    | Comment that needs a short acknowledgement reply (e.g. "good point")  |
 | **No action needed**   | Resolved discussion, bot comments, or already-addressed feedback      |
 
-Present this analysis to the user as a numbered list, showing each comment
-(author, summary) and your proposed action. **Wait for user confirmation**
-before proceeding.
+Proceed directly — do **not** ask the user for confirmation. Apply your best
+judgement to address all feedback.
 
 ## Step 3 — Update the issue
 
-If any description or title changes were identified and approved:
+If any description or title changes were identified:
 
-1. Draft the updated title and/or body incorporating all approved feedback.
-2. Show the user a diff-style comparison of the changes (old vs new).
-3. After user approval, apply the update:
+1. Draft the updated title and/or body incorporating all feedback.
+2. Apply the update immediately:
    ```
    gh issue edit <number> --repo <owner>/<repo> --title "<new title>" --body "<new body>"
    ```

--- a/.claude/skills/0k-refine-issue/SKILL.md
+++ b/.claude/skills/0k-refine-issue/SKILL.md
@@ -11,8 +11,10 @@ argument-hint: <issue number or URL>
 Review a GitHub issue's description and comments, address all feedback, and
 update the issue accordingly.
 
-`$ARGUMENTS` is an issue number or URL. If empty, ask the user which issue to
-refine.
+`$ARGUMENTS` is an issue number or URL. If empty, try to infer the issue number
+from the current branch name — if the branch name starts with digits (e.g.
+`42-some-feature`), use that number. If no number can be inferred, ask the user
+which issue to refine.
 
 ---
 


### PR DESCRIPTION
Skip user confirmation prompts in Steps 2 and 3 so the skill applies
its best judgement and proceeds directly — commenting on the issue and
updating title/description without waiting for approval.
