### PR TITLE
claude/implement-issue-37-yvygx

### DIFF
--- a/0k/skills/fix-pr/SKILL.md
+++ b/0k/skills/fix-pr/SKILL.md
@@ -97,6 +97,10 @@ replying. Do **not** accumulate multiple groups into one commit.
 
 ### 4a — Commit loop (repeat for every group)
 
+Before starting this loop, use `TodoWrite` to create **one task per group** (in
+order), so the full work queue is visible upfront. This queue must be fully
+completed before moving on to Step 4b.
+
 For each group of related change requests, in order:
 
 1. Read the files involved to understand the full context.
@@ -104,7 +108,8 @@ For each group of related change requests, in order:
 3. Invoke the `/0k:commit` skill with the `!` flag, passing the change request
    context as the argument.
 4. Record the resulting commit SHA alongside the group (you will need it in
-   Step 4c). Then **immediately continue to the next group** — do not push yet.
+   Step 4c). Mark the corresponding `TodoWrite` task as completed. Then
+   **immediately continue to the next group** — do not push yet.
 
 ### 4b — Push once
 

--- a/0k/skills/plan-execute/SKILL.md
+++ b/0k/skills/plan-execute/SKILL.md
@@ -13,18 +13,23 @@ tool on that file to learn the PLAN.md structure.
 
 Run every remaining step in PLAN.md, one after another, until none are left.
 
-**Procedure — loop until done:**
+**Procedure:**
 
-1. Read PLAN.md and find the first unchecked (`- [ ]`) step.
-2. If no unchecked step exists → stop and report "Plan complete."
-3. Otherwise, execute that step exactly as `/0k:plan-next` would (implement,
-   mark done, commit, update plan if needed).
-4. Go back to step 1.
+1. Read PLAN.md and collect **all** unchecked (`- [ ]`) steps.
+2. If no unchecked steps exist → stop and report "Plan complete."
+3. Use `TodoWrite` to create **one task per unchecked step** (in order), so the
+   full work queue is visible upfront before any execution begins.
+4. For each task in the `TodoWrite` list (in order):
+   - Execute the step exactly as `/0k:plan-next` would (implement, mark the
+     step done in PLAN.md, commit, update plan if needed).
+   - Mark the corresponding `TodoWrite` task as completed.
+   - Continue immediately to the next task.
+5. Once every `TodoWrite` task is marked done, report "Plan complete."
 
-**Important:** Do NOT stop after a single step. The whole point of `execute` is
-to finish the entire plan autonomously. Keep going until every step is checked
-off or an unrecoverable error forces you to stop (in which case, explain what
-blocked you and which steps remain).
+**Important:** Do NOT stop after a single step. The `TodoWrite` list is the
+complete work queue — keep going until every task is checked off. Only stop on
+an unrecoverable error (in which case, explain what blocked you and which steps
+remain).
 
 **After all steps are complete:**
 


### PR DESCRIPTION
Both skills relied on natural-language loop instructions, which the model
treats as a stopping point after each commit. By creating an explicit TodoWrite
task queue upfront (one task per step/group), the visible incomplete items keep
the model running until the entire queue is checked off.

Closes #37