### PR TITLE
feat(plan-init): auto-create branch when invoked from main

### DIFF
--- a/0k/skills/plan-init/SKILL.md
+++ b/0k/skills/plan-init/SKILL.md
@@ -21,6 +21,22 @@ following the format defined in `PLAN_FORMAT.md`. Include the link, a summary
 of the issue, the overall approach, a TOC checklist with anchor links, and a
 detailed section for each step describing what to implement and how.
 
+**Before creating PLAN.md**, check the current branch:
+
+```
+git branch --show-current
+```
+
+If the current branch is `main` or `master`, create and checkout a new branch
+derived from the issue. Build the branch name as `{issue-number}-{slug}` where
+`{slug}` is the issue title lowercased, spaces replaced with hyphens, special
+characters stripped, and truncated to keep the total branch name readable (aim
+for ≤ 50 characters). Then run:
+
+```
+git checkout -b {branch-name}
+```
+
 After creating PLAN.md:
 
 1. Run `/0k:commit ! plan: {issue title}` to commit it.

--- a/0k/skills/plan-init/SKILL.md
+++ b/0k/skills/plan-init/SKILL.md
@@ -27,15 +27,20 @@ detailed section for each step describing what to implement and how.
 git branch --show-current
 ```
 
-If the current branch is `main` or `master`, create and checkout a new branch
-derived from the issue. Build the branch name as `{issue-number}-{slug}` where
-`{slug}` is the issue title lowercased, spaces replaced with hyphens, special
-characters stripped, and truncated to keep the total branch name readable (aim
-for ≤ 50 characters). Then run:
+If the current branch is `main` or `master`, create a new branch derived from
+the issue. Build the branch name as `{issue-number}-{slug}` where `{slug}` is
+the issue title lowercased, spaces replaced with hyphens, special characters
+stripped, and kept to **≤ 20 characters** — pick 2–3 words that capture the
+area or context (the issue number already provides full traceability). Then
+run:
 
 ```
-git checkout -b {branch-name}
+gh issue develop {issue-number} --name {branch-name}
+wt switch {branch-name}
 ```
+
+`gh issue develop` creates the branch and links it to the issue on GitHub.
+`wt switch` switches to it via a worktree.
 
 After creating PLAN.md:
 


### PR DESCRIPTION
When plan-init is run on main or master, derive a branch name from
the issue number and slugified title, create and checkout it, then
proceed with the existing plan/commit/draft-PR flow.

Closes #43

https://claude.ai/code/session_01PzZ4kyqvoQrUCVpg4guH8P