### PR TITLE
fix(plugin): use object format for author field in plugin.json

### DIFF
--- a/0k/.claude-plugin/plugin.json
+++ b/0k/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "0k",
   "description": "0k-software org skills — commit, rebase, issue management, branch workflows, and more",
   "version": "1.0.0",
-  "author": "0k-software",
+  "author": { "name": "0k-software" },
   "license": "MIT",
   "homepage": "https://github.com/0k-software/.github",
   "repository": "https://github.com/0k-software/.github"


### PR DESCRIPTION
Fix the `author` field in `0k/.claude-plugin/plugin.json` — it was a plain
string but Claude Code's plugin system expects an object with at least a `name`
property.
