### PR TITLE
claude/conditional-make-commands-Euj55

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "make all"
+            "command": "make setup && ([ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && make install-plugin || true)"
           }
         ]
       }


### PR DESCRIPTION
Local sessions already have the plugin installed globally; remote sessions
need it installed per-project each time since ~/.claude/plugins/ isn't
available. Use CLAUDE_CODE_REMOTE=true to distinguish.

https://claude.ai/code/session_01EcnhATvKH4QoeQHB2UEKXj