### PR TITLE
Remove continue-on-error from hide-addressed-reviews step

### DIFF
--- a/hide-addressed-reviews/action.yml
+++ b/hide-addressed-reviews/action.yml
@@ -43,7 +43,6 @@ runs:
   steps:
     - name: Hide fully-addressed reviews
       shell: bash
-      continue-on-error: true
       env:
         GH_TOKEN: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
         PR_NUMBER: ${{ inputs.pr-number != '' && inputs.pr-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Removed the `continue-on-error: true` configuration from the "Hide fully-addressed reviews" step in the GitHub Action workflow.

## Changes
- Removed `continue-on-error: true` from the step configuration, allowing the action to fail if an error occurs rather than silently continuing

## Details
This change makes the action's error handling more strict. Previously, any errors encountered while hiding addressed reviews would be suppressed and the workflow would continue. Now, if the step fails, it will properly report the failure, which is important for visibility into potential issues with the review hiding functionality.

https://claude.ai/code/session_01R8NhVmnatHATsDgkzcYBL2