### PR TITLE
Optimize CI workflow: limit triggers and add concurrency control

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  Check:
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,11 @@ name: Check
 
 on:
   pull_request:
-  push:
-    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: check-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Updated the GitHub Actions check workflow to be more efficient by restricting when it runs and adding concurrency controls to prevent redundant executions.

## Key Changes
- **Removed push trigger**: The workflow no longer runs on every push to main, reducing unnecessary CI executions
- **Refined pull request trigger**: Now explicitly specifies PR event types (opened, synchronize, reopened, ready_for_review) instead of running on all PR events
- **Added concurrency control**: Implemented concurrency grouping to cancel in-progress runs when new commits are pushed, preventing duplicate workflow executions
- **Normalized job naming**: Changed job name from `Check` to `check` for consistency with naming conventions

## Implementation Details
- Concurrency is grouped by `github.head_ref` (for PRs) or `github.ref` (for other events), ensuring only one workflow runs per branch at a time
- The `cancel-in-progress: true` setting automatically cancels previous runs when a new one is triggered, saving CI resources

https://claude.ai/code/session_01DY5XNi6KwT9FSBH7NhrJMV